### PR TITLE
ci: run checks for changeset release branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches:
+      - "main"
+      - "changeset-release/**"
   pull_request:
     branches: [ "main" ]
   merge_group:
@@ -50,7 +52,7 @@ jobs:
     name: Publish / npm
     runs-on: ubuntu-latest
     needs: [success]
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
Ensures changeset-release branches receive the required CI checks, while keeping npm publish restricted to pushes on main only.