### PR TITLE
fix(types,client): align Brickset params and add runtime guards

### DIFF
--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -244,6 +244,7 @@ export class BricksetApiClient {
     params: GetSetsOptions,
     options: FetchOptions & FetchBricksetApiOptions & { apiKey?: string; userHash?: string } = {},
   ): Promise<EndpointType<'/api/v3.asmx/getSets'>> {
+    validateGetSetsParams(params);
     const { apiKey, userHash, ...rest } = options;
     const resolvedUserHash = userHash ?? this.auth?.userHash;
 
@@ -380,6 +381,7 @@ export class BricksetApiClient {
     params: SetMinifigCollectionParams,
     options: FetchOptions & FetchBricksetApiOptions & { apiKey?: string; userHash?: string } = {},
   ): Promise<EndpointType<'/api/v3.asmx/setMinifigCollection'>> {
+    validateSetMinifigCollectionParams(params);
     const { apiKey, userHash, ...rest } = options;
     return this.request('/api/v3.asmx/setMinifigCollection', {
       ...rest,
@@ -394,6 +396,7 @@ export class BricksetApiClient {
     params: SetUserFlagLabelsParams,
     options: FetchOptions & FetchBricksetApiOptions & { apiKey?: string; userHash?: string } = {},
   ): Promise<EndpointType<'/api/v3.asmx/setUserFlagLabels'>> {
+    validateSetUserFlagLabelsParams(params);
     const { apiKey, userHash, ...rest } = options;
     return this.request('/api/v3.asmx/setUserFlagLabels', {
       ...rest,
@@ -444,6 +447,7 @@ export class BricksetApiClient {
     params: SetCollectionParams,
     options: FetchOptions & FetchBricksetApiOptions & { apiKey?: string; userHash?: string } = {},
   ): Promise<EndpointType<'/api/v3.asmx/setCollection'>> {
+    validateSetCollectionParams(params);
     const { apiKey, userHash, ...rest } = options;
     return this.request('/api/v3.asmx/setCollection', {
       ...rest,
@@ -574,4 +578,50 @@ function normalizeConcurrency(value: number | undefined): number {
     throw new Error('concurrency must be a positive integer.');
   }
   return value;
+}
+
+function validateGetSetsParams(params: GetSetsOptions): void {
+  if (params.pageSize !== undefined) {
+    assertIntegerInRange(params.pageSize, 1, 500, 'getSets params.pageSize');
+  }
+  if (params.pageNumber !== undefined) {
+    assertIntegerInRange(params.pageNumber, 1, Number.MAX_SAFE_INTEGER, 'getSets params.pageNumber');
+  }
+}
+
+function validateSetCollectionParams(params: SetCollectionParams): void {
+  validateOptionalQuantity(params.qtyOwned, 'setCollection params.qtyOwned');
+  validateOptionalQuantity(params.qtyWanted, 'setCollection params.qtyWanted');
+  validateOptionalQuantity(params.qtyOwnedNew, 'setCollection params.qtyOwnedNew');
+  validateOptionalQuantity(params.qtyOwnedUsed, 'setCollection params.qtyOwnedUsed');
+  if (params.rating !== undefined) {
+    assertIntegerInRange(params.rating, 1, 5, 'setCollection params.rating');
+  }
+}
+
+function validateSetMinifigCollectionParams(params: SetMinifigCollectionParams): void {
+  validateOptionalQuantity(params.qtyOwned, 'setMinifigCollection params.qtyOwned');
+}
+
+function validateSetUserFlagLabelsParams(params: SetUserFlagLabelsParams): void {
+  for (const key in params) {
+    if (!Object.prototype.hasOwnProperty.call(params, key)) continue;
+    const value = params[key as keyof SetUserFlagLabelsParams];
+    if (value !== undefined && String(value).length > 20) {
+      throw new Error(`setUserFlagLabels params.${key} must be 20 characters or fewer.`);
+    }
+  }
+}
+
+function validateOptionalQuantity(value: number | undefined, name: string): void {
+  if (value === undefined) {
+    return;
+  }
+  assertIntegerInRange(value, 0, 999, name);
+}
+
+function assertIntegerInRange(value: number, min: number, max: number, name: string): void {
+  if (!Number.isInteger(value) || value < min || value > max) {
+    throw new Error(`${name} must be an integer between ${min} and ${max}.`);
+  }
 }

--- a/packages/types/data/get-sets.ts
+++ b/packages/types/data/get-sets.ts
@@ -29,11 +29,7 @@ export type GetSetsOrderBy = OrderByBase | `${OrderByBase}DESC`;
 
 export type GetSetsOptions = {
   setID?: number;
-  query?: {
-    setNumber?: string;
-    theme?: string;
-    subtheme?: string;
-  };
+  query?: string;
   theme?: string | string[];
   subtheme?: string | string[];
   setNumber?: string | string[];

--- a/packages/types/endpoints.ts
+++ b/packages/types/endpoints.ts
@@ -114,7 +114,18 @@ export type SetMinifigCollectionParams = {
   notes?: string;
 };
 
-export type SetUserFlagLabelsParams = Partial<Record<'1' | '2' | '3' | '4' | '5' | '6' | '7' | '8', string>>;
+type Max20Chars<S extends string> =
+  S extends `${infer A}${infer B}${infer C}${infer D}${infer E}${infer F}${infer G}${infer H}${infer I}${infer J}${infer K}${infer L}${infer M}${infer N}${infer O}${infer P}${infer Q}${infer R}${infer T}${infer U}${infer Rest}`
+    ? never
+    : S;
+
+export type FlagLabelValue = string & { readonly __max20Chars?: unique symbol };
+export type SetUserFlagLabelsParams =
+  Partial<Record<'1' | '2' | '3' | '4' | '5' | '6' | '7' | '8', FlagLabelValue>>;
+
+export function asFlagLabel<T extends string>(value: Max20Chars<T>): FlagLabelValue {
+  return value as FlagLabelValue;
+}
 
 // options
 type Options = {};


### PR DESCRIPTION
Closes the audit gaps:

- Aligns getSets params.query to Brickset docs (string search term)
- Adds stricter SetUserFlagLabels typing and helper for max-20-char labels
- Adds runtime guards in client for documented parameter limits:
  - getSets pageSize/pageNumber bounds
  - setCollection qty/rating bounds
  - setMinifigCollection qty bounds
  - setUserFlagLabels value length bounds

Validated with workspace type checks and client integration test.