### PR TITLE
chore(packages): mark client and fetch as ESM modules

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.2",
   "description": "High-level client for the Brickset API with middleware and caching primitives",
   "license": "MIT",
+  "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": {

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.20",
   "description": "Tiny wrapper around fetch that returns type-safe responses",
   "license": "MIT",
+  "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": {


### PR DESCRIPTION
Sets "type": "module" for @brickset-api/client and @brickset-api/fetch so runtime module format matches emitted JS and avoids MODULE_TYPELESS_PACKAGE_JSON warnings.