### PR TITLE
docs: add professional READMEs for types and fetch packages

### DIFF
--- a/packages/fetch/README.md
+++ b/packages/fetch/README.md
@@ -1,0 +1,40 @@
+# @brickset-api/fetch
+
+Tiny fetch wrapper for Brickset API v3 with strong TypeScript response typing.
+
+Built to be a minimal low-level layer for:
+
+- `@brickset-api/client` (high-level API client)
+- advanced users who want direct request control
+
+## Install
+
+```bash
+pnpm add @brickset-api/fetch @brickset-api/types
+```
+
+## Usage
+
+```ts
+import { fetchBricksetApi } from '@brickset-api/fetch';
+
+const response = await fetchBricksetApi('/api/v3.asmx/getThemes', {
+  apiKey: process.env.BRICKSET_API_KEY!,
+});
+
+if (response.status === 'success') {
+  console.log(response.themes);
+}
+```
+
+## Features
+
+- Endpoint-aware response types via `@brickset-api/types`
+- Query serialization for Brickset-compatible URL parameters
+- Optional request/response hooks
+- Typed error class (`BricksetApiError`) for non-2xx responses
+
+## Security notes
+
+- Pass API key and user hash from secure config (env/secrets), never hardcode.
+- Prefer `@brickset-api/client` when you need sanitization and guardrails by default.

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -1,0 +1,29 @@
+# @brickset-api/types
+
+Strong TypeScript types for Brickset API v3 endpoints, options, and response data.
+
+## Install
+
+```bash
+pnpm add @brickset-api/types
+```
+
+## Usage
+
+```ts
+import type { EndpointType, OptionsByEndpoint } from '@brickset-api/types/endpoints';
+
+type GetThemesResponse = EndpointType<'/api/v3.asmx/getThemes'>;
+type GetSetsOptions = OptionsByEndpoint<'/api/v3.asmx/getSets?params={"query":"technic"}'>;
+```
+
+## What is included
+
+- Endpoint contracts (`KnownEndpoint`, `OptionsByEndpoint`, `EndpointType`)
+- Shared API response wrappers (`success` and `error` variants)
+- Data models under `@brickset-api/types/data/*`
+
+## Notes
+
+- The package is TypeScript-first and intended for compile-time safety.
+- Runtime validation belongs in `@brickset-api/client`.


### PR DESCRIPTION
## Summary
- add README for @brickset-api/types
- add README for @brickset-api/fetch
- align package documentation with TypeScript-first package positioning

## Validation
- pnpm test