### PR TITLE
docs: add central endpoint coverage matrix for all packages

### DIFF
--- a/docs/endpoint-coverage.md
+++ b/docs/endpoint-coverage.md
@@ -1,0 +1,41 @@
+# Brickset API Endpoint Coverage
+
+This matrix tracks coverage for Brickset API v3 endpoints across:
+
+- `@brickset-api/types` (endpoint options and response typing)
+- `@brickset-api/fetch` (typed transport and query serialization)
+- `@brickset-api/client` (high-level method wrapper)
+
+Legend:
+
+- `yes`: implemented and available
+- `partial`: available, but with limited higher-level convenience
+
+| Endpoint | types | fetch | client |
+| --- | --- | --- | --- |
+| `/api/v3.asmx/login` | yes | yes | yes |
+| `/api/v3.asmx/checkKey` | yes | yes | yes |
+| `/api/v3.asmx/checkUserHash` | yes | yes | yes |
+| `/api/v3.asmx/getKeyUsageStats` | yes | yes | yes |
+| `/api/v3.asmx/getSets` | yes | yes | yes |
+| `/api/v3.asmx/getAdditionalImages` | yes | yes | yes |
+| `/api/v3.asmx/getInstructions` | yes | yes | yes |
+| `/api/v3.asmx/getInstructions2` | yes | yes | yes |
+| `/api/v3.asmx/getReviews` | yes | yes | yes |
+| `/api/v3.asmx/getThemes` | yes | yes | yes |
+| `/api/v3.asmx/getSubthemes` | yes | yes | yes |
+| `/api/v3.asmx/getYears` | yes | yes | yes |
+| `/api/v3.asmx/getCollection` | yes | yes | yes |
+| `/api/v3.asmx/setCollection` | yes | yes | yes |
+| `/api/v3.asmx/getUserNotes` | yes | yes | yes |
+| `/api/v3.asmx/getUserFlagLabels` | yes | yes | yes |
+| `/api/v3.asmx/setUserFlagLabels` | yes | yes | yes |
+| `/api/v3.asmx/getMinifigCollection` | yes | yes | yes |
+| `/api/v3.asmx/setMinifigCollection` | yes | yes | yes |
+| `/api/v3.asmx/getUserMinifigNotes` | yes | yes | yes |
+
+## Notes
+
+- `@brickset-api/fetch` intentionally stays low-level and endpoint-generic.
+- `@brickset-api/client` adds validation, sane defaults, sanitization, and middleware support.
+- Keep this file updated whenever new endpoints or method wrappers are added.

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -55,6 +55,7 @@ const minifigs = await client.getMinifigCollection({ owned: 1 });
 - Set details: `getAdditionalImages`, `getInstructions`, `getInstructionsBySetNumber`, `getReviews`
 - User data: `getCollection`, `setCollection`, `getUserNotes`, `getUserFlagLabels`, `setUserFlagLabels`, `getUserMinifigNotes`, `getMinifigCollection`, `setMinifigCollection`
 - Usage: `getKeyUsageStats`
+- Full package matrix: [`docs/endpoint-coverage.md`](../../docs/endpoint-coverage.md)
 
 ## Extensibility
 

--- a/packages/fetch/README.md
+++ b/packages/fetch/README.md
@@ -33,6 +33,7 @@ if (response.status === 'success') {
 - Query serialization for Brickset-compatible URL parameters
 - Optional request/response hooks
 - Typed error class (`BricksetApiError`) for non-2xx responses
+- Coverage matrix: [`docs/endpoint-coverage.md`](../../docs/endpoint-coverage.md)
 
 ## Security notes
 

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -22,6 +22,7 @@ type GetSetsOptions = OptionsByEndpoint<'/api/v3.asmx/getSets?params={"query":"t
 - Endpoint contracts (`KnownEndpoint`, `OptionsByEndpoint`, `EndpointType`)
 - Shared API response wrappers (`success` and `error` variants)
 - Data models under `@brickset-api/types/data/*`
+- Coverage matrix: [`docs/endpoint-coverage.md`](../../docs/endpoint-coverage.md)
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- add central Brickset API endpoint coverage matrix
- link matrix from types, fetch, and client READMEs
- document coverage tracking guidance

## Validation
- pnpm test