### PR TITLE
ci: enforce workspace dependency version policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
     - run: pnpm install --frozen-lockfile
     - run: pnpm test:coverage-script
     - run: pnpm verify:coverage
+    - run: pnpm verify:workspace-versions
     - run: pnpm test
     - run: pnpm build
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test": "pnpm -r test",
     "build": "pnpm -r build",
     "verify:coverage": "node scripts/verify-endpoint-coverage.mjs",
+    "verify:workspace-versions": "node scripts/verify-workspace-versions.mjs",
     "test:coverage-script": "node --test scripts/verify-endpoint-coverage.test.mjs",
     "release": "pnpm build && changeset publish"
   },

--- a/scripts/verify-workspace-versions.mjs
+++ b/scripts/verify-workspace-versions.mjs
@@ -1,0 +1,67 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const ROOT = process.cwd();
+const PACKAGES_DIR = resolve(ROOT, 'packages');
+
+const packageDirs = readdirSync(PACKAGES_DIR, { withFileTypes: true })
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => entry.name);
+
+const packages = packageDirs.map((dirName) => {
+  const file = join(PACKAGES_DIR, dirName, 'package.json');
+  const content = JSON.parse(readFileSync(file, 'utf8'));
+  return {
+    dirName,
+    file,
+    name: content.name,
+    version: content.version,
+    manifest: content,
+  };
+});
+
+const workspaceByName = new Map(packages.map((pkg) => [pkg.name, pkg]));
+const errors = [];
+
+for (const pkg of packages) {
+  verifyInternalRanges(pkg, 'dependencies');
+  verifyInternalRanges(pkg, 'devDependencies');
+  verifyInternalRanges(pkg, 'optionalDependencies');
+  verifyPeerRanges(pkg);
+}
+
+if (errors.length > 0) {
+  console.error('Workspace version policy verification failed:');
+  for (const error of errors) {
+    console.error(`- ${error}`);
+  }
+  process.exit(1);
+}
+
+console.log(`Workspace version policy verified (${packages.length} packages).`);
+
+function verifyInternalRanges(pkg, field) {
+  const deps = pkg.manifest[field];
+  if (!deps || typeof deps !== 'object') return;
+
+  for (const [depName, depRange] of Object.entries(deps)) {
+    if (!workspaceByName.has(depName)) continue;
+    if (depRange !== 'workspace:*') {
+      errors.push(`${pkg.name} ${field}.${depName} should be "workspace:*" (found "${depRange}").`);
+    }
+  }
+}
+
+function verifyPeerRanges(pkg) {
+  const peerDeps = pkg.manifest.peerDependencies;
+  if (!peerDeps || typeof peerDeps !== 'object') return;
+
+  for (const [depName, depRange] of Object.entries(peerDeps)) {
+    const depPkg = workspaceByName.get(depName);
+    if (!depPkg) continue;
+    const expected = `~${depPkg.version}`;
+    if (depRange !== expected) {
+      errors.push(`${pkg.name} peerDependencies.${depName} should be "${expected}" (found "${depRange}").`);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add workspace version policy verifier script
- enforce internal workspace dependencies to remain `workspace:*`
- enforce internal peerDependencies to match `~<current workspace version>`
- run policy verifier in CI

## Validation
- pnpm verify:workspace-versions
- pnpm test:coverage-script
- pnpm verify:coverage
- pnpm test