### PR TITLE
ci: harden publish artifact policy for npm packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
     - run: pnpm test:coverage-script
     - run: pnpm verify:coverage
     - run: pnpm verify:workspace-versions
+    - run: pnpm verify:pack
     - run: pnpm test
     - run: pnpm build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,9 +40,9 @@ jobs:
     - run: pnpm test:coverage-script
     - run: pnpm verify:coverage
     - run: pnpm verify:workspace-versions
-    - run: pnpm verify:pack
     - run: pnpm test
     - run: pnpm build
+    - run: pnpm verify:pack
 
   success:
     name: Success

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "pnpm -r build",
     "verify:coverage": "node scripts/verify-endpoint-coverage.mjs",
     "verify:workspace-versions": "node scripts/verify-workspace-versions.mjs",
+    "verify:pack": "node scripts/verify-publish-artifacts.mjs",
     "test:coverage-script": "node --test scripts/verify-endpoint-coverage.test.mjs",
     "release": "pnpm build && changeset publish"
   },

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -18,6 +18,11 @@
     "api",
     "typescript"
   ],
+  "files": [
+    "dist",
+    "README.md",
+    "CHANGELOG.md"
+  ],
   "scripts": {
     "test": "pnpm -C ../fetch build && tsc --noEmit",
     "build": "tsc",

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -17,6 +17,11 @@
     "brickset",
     "api"
   ],
+  "files": [
+    "dist",
+    "README.md",
+    "CHANGELOG.md"
+  ],
   "scripts": {
     "test": "tsc --noEmit",
     "build": "tsc",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -23,6 +23,12 @@
     "api",
     "typescript"
   ],
+  "files": [
+    "endpoints.ts",
+    "data",
+    "README.md",
+    "CHANGELOG.md"
+  ],
   "scripts": {
     "test": "tsc",
     "build": "tsc"

--- a/scripts/verify-publish-artifacts.mjs
+++ b/scripts/verify-publish-artifacts.mjs
@@ -1,0 +1,80 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const ROOT = process.cwd();
+
+const POLICIES = [
+  {
+    dir: 'packages/types',
+    expectedFiles: ['endpoints.ts', 'data', 'README.md', 'CHANGELOG.md'],
+    requiredFields: ['name', 'version', 'license', 'files'],
+  },
+  {
+    dir: 'packages/fetch',
+    expectedFiles: ['dist', 'README.md', 'CHANGELOG.md'],
+    requiredFields: ['name', 'version', 'license', 'main', 'types', 'files'],
+  },
+  {
+    dir: 'packages/client',
+    expectedFiles: ['dist', 'README.md', 'CHANGELOG.md'],
+    requiredFields: ['name', 'version', 'license', 'main', 'types', 'files'],
+  },
+];
+
+const errors = [];
+
+for (const policy of POLICIES) {
+  const pkgPath = resolve(ROOT, policy.dir, 'package.json');
+  const manifest = JSON.parse(readFileSync(pkgPath, 'utf8'));
+  const files = manifest.files;
+
+  for (const field of policy.requiredFields) {
+    if (manifest[field] === undefined) {
+      errors.push(`${policy.dir}: missing required package.json field "${field}"`);
+    }
+  }
+
+  if (!Array.isArray(files)) {
+    errors.push(`${policy.dir}: "files" must be an array`);
+    continue;
+  }
+
+  const normalized = [...files].sort();
+  const expected = [...policy.expectedFiles].sort();
+  if (JSON.stringify(normalized) !== JSON.stringify(expected)) {
+    errors.push(
+      `${policy.dir}: "files" must exactly equal [${expected.join(', ')}], found [${normalized.join(', ')}]`,
+    );
+  }
+
+  for (const item of files) {
+    const path = resolve(ROOT, policy.dir, item);
+    if (!existsSync(path)) {
+      errors.push(`${policy.dir}: publish file path does not exist on disk: "${item}"`);
+    }
+  }
+
+  if (typeof manifest.main === 'string') {
+    const mainPath = resolve(ROOT, policy.dir, manifest.main);
+    if (!existsSync(mainPath)) {
+      errors.push(`${policy.dir}: "main" points to missing file "${manifest.main}"`);
+    }
+  }
+
+  if (typeof manifest.types === 'string') {
+    const typesPath = resolve(ROOT, policy.dir, manifest.types);
+    if (!existsSync(typesPath)) {
+      errors.push(`${policy.dir}: "types" points to missing file "${manifest.types}"`);
+    }
+  }
+}
+
+if (errors.length > 0) {
+  console.error('Publish artifact policy verification failed:');
+  for (const error of errors) {
+    console.error(`- ${error}`);
+  }
+  process.exit(1);
+}
+
+console.log(`Publish artifact policy verified (${POLICIES.length} packages).`);


### PR DESCRIPTION
## Summary
- add publish artifact policy verifier
- enforce strict `files` whitelists for client/fetch/types packages
- verify package main/types paths and publish metadata in CI
- run `pnpm verify:pack` in CI

## Validation
- pnpm verify:pack
- pnpm verify:workspace-versions
- pnpm test:coverage-script
- pnpm verify:coverage
- pnpm test