### PR TITLE
ci: guard public API surface against unintended breaking changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
     - run: pnpm verify:workspace-versions
     - run: pnpm test
     - run: pnpm build
+    - run: pnpm verify:api-surface
     - run: pnpm verify:pack
 
   success:

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "verify:coverage": "node scripts/verify-endpoint-coverage.mjs",
     "verify:workspace-versions": "node scripts/verify-workspace-versions.mjs",
     "verify:pack": "node scripts/verify-publish-artifacts.mjs",
+    "verify:api-surface": "node scripts/verify-api-surface.mjs",
+    "verify:api-surface:update": "node scripts/verify-api-surface.mjs --update",
     "test:coverage-script": "node --test scripts/verify-endpoint-coverage.test.mjs",
     "release": "pnpm build && changeset publish"
   },

--- a/scripts/api-surface.baseline.json
+++ b/scripts/api-surface.baseline.json
@@ -1,0 +1,25 @@
+{
+  "@brickset-api/fetch": [
+    "BricksetApiError",
+    "FetchBricksetApiOptions",
+    "FetchOptions",
+    "fetchBricksetApi"
+  ],
+  "@brickset-api/client": [
+    "BricksetApiClient",
+    "BricksetBatchRequest",
+    "BricksetBatchResult",
+    "BricksetClientCache",
+    "BricksetClientError",
+    "BricksetClientMiddleware",
+    "BricksetClientOptions",
+    "BricksetClientRequest",
+    "BricksetClientRequestOptions",
+    "InMemoryBricksetClientCache",
+    "RequestBatchOptions",
+    "RetryMiddlewareOptions",
+    "createRateLimitMiddleware",
+    "createRetryMiddleware",
+    "createTimeoutMiddleware"
+  ]
+}

--- a/scripts/verify-api-surface.mjs
+++ b/scripts/verify-api-surface.mjs
@@ -1,0 +1,86 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const ROOT = process.cwd();
+const BASELINE_FILE = resolve(ROOT, 'scripts/api-surface.baseline.json');
+
+const TARGETS = [
+  {
+    name: '@brickset-api/fetch',
+    declarationFile: resolve(ROOT, 'packages/fetch/dist/index.d.ts'),
+  },
+  {
+    name: '@brickset-api/client',
+    declarationFile: resolve(ROOT, 'packages/client/dist/index.d.ts'),
+  },
+];
+
+const shouldUpdate = process.argv.includes('--update');
+const current = Object.fromEntries(TARGETS.map((target) => [target.name, collectSymbols(target.declarationFile)]));
+
+if (shouldUpdate) {
+  writeFileSync(BASELINE_FILE, `${JSON.stringify(current, null, 2)}\n`, 'utf8');
+  console.log(`API surface baseline updated: ${BASELINE_FILE}`);
+  process.exit(0);
+}
+
+const baseline = JSON.parse(readFileSync(BASELINE_FILE, 'utf8'));
+const errors = [];
+
+for (const target of TARGETS) {
+  const name = target.name;
+  const currentSymbols = current[name] ?? [];
+  const baselineSymbols = baseline[name] ?? [];
+
+  const removed = baselineSymbols.filter((symbol) => !currentSymbols.includes(symbol));
+  const added = currentSymbols.filter((symbol) => !baselineSymbols.includes(symbol));
+
+  if (removed.length > 0 || added.length > 0) {
+    errors.push(formatDiff(name, removed, added));
+  }
+}
+
+if (errors.length > 0) {
+  console.error('Public API surface verification failed.\n');
+  for (const error of errors) {
+    console.error(error);
+  }
+  console.error('\nIf these API changes are intentional, run: pnpm verify:api-surface:update');
+  process.exit(1);
+}
+
+console.log(`Public API surface verified (${TARGETS.length} packages).`);
+
+function collectSymbols(filePath) {
+  const source = readFileSync(filePath, 'utf8');
+  const symbols = new Set();
+
+  for (const match of source.matchAll(/^export\s+(?:declare\s+)?(?:class|function|const|type|interface)\s+([A-Za-z0-9_]+)/gm)) {
+    symbols.add(match[1]);
+  }
+
+  for (const match of source.matchAll(/^export\s*{\s*([^}]+)\s*};?$/gm)) {
+    const chunk = match[1];
+    for (const piece of chunk.split(',')) {
+      const trimmed = piece.trim();
+      if (!trimmed) continue;
+      const local = trimmed.split(/\s+as\s+/i)[0].trim();
+      if (local) symbols.add(local);
+    }
+  }
+
+  return [...symbols].sort();
+}
+
+function formatDiff(pkgName, removed, added) {
+  const lines = [`${pkgName}:`];
+  if (removed.length > 0) {
+    lines.push('  removed symbols:');
+    for (const symbol of removed) lines.push(`  - ${symbol}`);
+  }
+  if (added.length > 0) {
+    lines.push('  added symbols:');
+    for (const symbol of added) lines.push(`  + ${symbol}`);
+  }
+  return lines.join('\n');
+}


### PR DESCRIPTION
## Summary
- add API surface verifier for fetch/client declaration outputs
- store committed baseline for public export symbols
- add update command for intentional API changes
- enforce API surface check in CI after build

## Validation
- pnpm verify:api-surface
- pnpm verify:pack
- pnpm verify:workspace-versions
- pnpm test:coverage-script
- pnpm verify:coverage
- pnpm test