### PR TITLE
ci: add optional live Brickset smoke checks before publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,11 +54,40 @@ jobs:
     - run: jq --exit-status 'all(.result == "success")' <<< '${{ toJson(needs) }}'
     - run: exit 0
 
+  smoke-live-api:
+    name: Smoke / Live Brickset API
+    runs-on: ubuntu-latest
+    needs: [success]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.BRICKSET_API_KEY != ''
+    steps:
+      - uses: actions/checkout@v6
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 11.4.0
+      - name: Use Node.js 24
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - name: Run live smoke checks
+        env:
+          BRICKSET_API_KEY: ${{ secrets.BRICKSET_API_KEY }}
+          BRICKSET_USER_HASH: ${{ secrets.BRICKSET_USER_HASH }}
+        run: pnpm smoke:live-api
+
   publish-npm:
     name: Publish / npm
     runs-on: ubuntu-latest
-    needs: [success]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [success, smoke-live-api]
+    if: >
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main' &&
+      (
+        needs.smoke-live-api.result == 'success' ||
+        needs.smoke-live-api.result == 'skipped'
+      )
     permissions:
       contents: write
       id-token: write

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "verify:pack": "node scripts/verify-publish-artifacts.mjs",
     "verify:api-surface": "node scripts/verify-api-surface.mjs",
     "verify:api-surface:update": "node scripts/verify-api-surface.mjs --update",
+    "smoke:live-api": "pnpm -C packages/fetch build && node scripts/smoke-live-api.mjs",
     "test:coverage-script": "node --test scripts/verify-endpoint-coverage.test.mjs",
     "release": "pnpm build && changeset publish"
   },

--- a/scripts/smoke-live-api.mjs
+++ b/scripts/smoke-live-api.mjs
@@ -1,0 +1,64 @@
+import { fetchBricksetApi } from '../packages/fetch/dist/index.js';
+
+const apiKey = process.env.BRICKSET_API_KEY;
+const userHash = process.env.BRICKSET_USER_HASH;
+
+if (!apiKey) {
+  console.error('Missing required BRICKSET_API_KEY.');
+  process.exit(1);
+}
+
+const checks = [];
+
+checks.push(await runCheck('checkKey', async () => {
+  const result = await fetchBricksetApi('/api/v3.asmx/checkKey', { apiKey });
+  return result.status === 'success';
+}));
+
+checks.push(await runCheck('getThemes', async () => {
+  const result = await fetchBricksetApi('/api/v3.asmx/getThemes', { apiKey });
+  return result.status === 'success' && Array.isArray(result.themes);
+}));
+
+checks.push(await runCheck('getYears(Technic)', async () => {
+  const result = await fetchBricksetApi('/api/v3.asmx/getYears', { apiKey, theme: 'Technic' });
+  return result.status === 'success' && Array.isArray(result.years);
+}));
+
+if (userHash) {
+  checks.push(await runCheck('checkUserHash', async () => {
+    const result = await fetchBricksetApi('/api/v3.asmx/checkUserHash', { apiKey, userHash });
+    return result.status === 'success';
+  }));
+}
+
+const failed = checks.filter((item) => !item.ok);
+if (failed.length > 0) {
+  console.error('Live smoke checks failed:');
+  for (const item of failed) {
+    console.error(`- ${item.name}: ${item.errorMessage}`);
+  }
+  process.exit(1);
+}
+
+console.log(`Live smoke checks passed (${checks.length} checks).`);
+
+async function runCheck(name, fn) {
+  try {
+    const ok = await fn();
+    if (!ok) {
+      return { name, ok: false, errorMessage: 'unexpected response shape' };
+    }
+    return { name, ok: true };
+  } catch (error) {
+    return { name, ok: false, errorMessage: sanitizeErrorMessage(error) };
+  }
+}
+
+function sanitizeErrorMessage(error) {
+  const raw = error instanceof Error ? error.message : String(error);
+  let value = raw;
+  if (apiKey) value = value.replaceAll(apiKey, '***');
+  if (userHash) value = value.replaceAll(userHash, '***');
+  return value;
+}


### PR DESCRIPTION
## Summary
- add live Brickset smoke script (read-only checks)
- run smoke checks on main push when BRICKSET_API_KEY is configured
- gate publish job on smoke result when smoke job runs
- sanitize secret values from error output

## Validation
- pnpm -C packages/fetch build
- pnpm test:coverage-script
- pnpm verify:coverage
- pnpm verify:workspace-versions
- pnpm verify:pack
- pnpm verify:api-surface