### PR TITLE
ci: make live smoke check optional for publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
   publish-npm:
     name: Publish / npm
     runs-on: ubuntu-latest
-    needs: [success, smoke-live-api]
+    needs: [success]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- keep live smoke check as optional signal
- do not block npm publish when smoke check fails or is skipped

## Change
- publish job now depends only on Success job