### PR TITLE
fix(types): professional compatibility and duplication cleanup

### DIFF
--- a/packages/types/data/get-sets.ts
+++ b/packages/types/data/get-sets.ts
@@ -1,3 +1,5 @@
+import type { Image } from './image';
+
 export type GetSets = GetSetsBase;
 
 type OrderByBase =
@@ -147,9 +149,4 @@ interface ItemNumbers {
 interface AgeRange {
   min?: number;
   max?: number;
-}
-
-interface Image {
-  thumbnailURL: string;
-  imageURL: string;
 }

--- a/packages/types/data/get-themes.ts
+++ b/packages/types/data/get-themes.ts
@@ -1,6 +1,6 @@
 export type GetThemes = GetThemesBase;
 
-export type GetThemesOptions = unknown;
+export type GetThemesOptions = Record<string, never>;
 
 export type GetThemesBase = {
   theme: string;

--- a/packages/types/data/years.ts
+++ b/packages/types/data/years.ts
@@ -1,5 +1,5 @@
 export type Years = {
   theme: string;
-  year: string;
+  year: number;
   setCount: number;
 };

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@brickset-api/types",
   "version": "0.0.19",
-  "description": "TypeScript types for all datastructures used by the Brickset API",
+  "description": "TypeScript types for all data structures used by the Brickset API",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- change Years.year to number for Brickset API compatibility
- reuse shared Image type in get-sets model (remove duplicate inline type)
- replace GetThemesOptions unknown placeholder with explicit empty options type
- polish @brickset-api/types package description wording

## Validation
- pnpm test:coverage-script
- pnpm verify:coverage
- pnpm verify:workspace-versions
- pnpm test
- pnpm build
- pnpm verify:api-surface
- pnpm verify:pack