### PR TITLE
fix(fetch): enforce JSON content-type before parsing response

### DIFF
--- a/packages/fetch/scripts/verify-query-serialization.mjs
+++ b/packages/fetch/scripts/verify-query-serialization.mjs
@@ -5,7 +5,12 @@ const assert = (cond, msg) => {
 const calls = [];
 globalThis.fetch = async (request) => {
   const req = request instanceof Request ? request : new Request(request);
-  calls.push(new URL(req.url));
+  const url = new URL(req.url);
+  calls.push(url);
+
+  if (url.pathname.endsWith('/getThemes')) {
+    return new Response('not json', { status: 200, headers: { 'content-type': 'text/plain' } });
+  }
 
   return new Response(
     JSON.stringify({ status: 'success', matches: 0, sets: [] }),
@@ -13,7 +18,7 @@ globalThis.fetch = async (request) => {
   );
 };
 
-const { fetchBricksetApi } = await import('../dist/index.js');
+const { fetchBricksetApi, BricksetApiError } = await import('../dist/index.js');
 
 await fetchBricksetApi('/api/v3.asmx/getSets', {
   apiKey: 'test-key',
@@ -27,7 +32,17 @@ await fetchBricksetApi('/api/v3.asmx/setCollection', {
   params: { own: 1, qtyOwned: 2 },
 });
 
-assert(calls.length === 2, 'Expected 2 fetch calls');
+let rejectedNonJson = false;
+try {
+  await fetchBricksetApi('/api/v3.asmx/getThemes', { apiKey: 'test-key' });
+} catch (error) {
+  rejectedNonJson =
+    error instanceof BricksetApiError &&
+    String(error.message).includes('did not respond with a JSON response');
+}
+assert(rejectedNonJson, 'Expected non-JSON response to throw BricksetApiError');
+
+assert(calls.length === 3, 'Expected 3 fetch calls');
 
 const [getSetsUrl, setCollectionUrl] = calls;
 assert(getSetsUrl.pathname === '/api/v3.asmx/getSets', 'getSets path mismatch');

--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -76,8 +76,9 @@ export async function fetchBricksetApi<
   // call onResponse handler
   await resolvedOptions.onResponse?.(response);
 
-  // check if the response is json (`application/json; charset=utf-8`)
-  const isJson = true; // response.headers.get('content-type').startsWith('application/json');
+  // only parse JSON when content-type indicates JSON
+  const contentType = response.headers.get('content-type') ?? '';
+  const isJson = contentType.toLowerCase().startsWith('application/json');
 
   // censor user hash in url to not leak it in error messages
   let erroredUrl = hasUserHash(resolvedOptions) && resolvedOptions.userHash !== ''


### PR DESCRIPTION
## Summary
- replace hardcoded JSON detection with content-type based detection
- add integration regression for non-JSON response handling

## Validation
- pnpm -C packages/fetch test:integration
- pnpm test
- pnpm verify:api-surface
- pnpm verify:pack